### PR TITLE
fix panic in CurrentBrahnc when there is no initial commit

### DIFF
--- a/api.go
+++ b/api.go
@@ -203,7 +203,18 @@ func CurrentBranch(repoPath string) (string, error) {
 		return "", headErr
 	}
 
-	return strings.Split(head.Name(), "/")[2], nil
+	if head == nil {
+		return "", headErr
+	}
+
+	//find the branch name
+	branch := ""
+	branchElements := strings.Split(head.Name(), "/")
+	if len(branchElements) == 3 {
+		branch = branchElements[2]
+	}
+
+	return branch, nil
 }
 
 func DeleteBranch(repoPath string, branchName string) error {


### PR DESCRIPTION
When you have  new repo with no initial commit, the CurrentBranch function panics because the head name is nil.  This checks for that case.  Also, I validate the bounds of the array because, hey, you should just do that...